### PR TITLE
PGP-428: Add made with Playpass banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,8 @@
       <p>This is an example of how to use the Playpass SDK to build a simple daily level phrase game.</p>
       <p>Each day, there's a different phrase to guess. You have 8 tries to get it right!</p>
       <button name="back">Continue</button>
+
+      <a class="fork-ribbon" href="https://playpass.games/" target="_blank">Made with Playpass</a>
     </div>
 
     <div slot="screen" id="stats-screen">


### PR DESCRIPTION
Before, there was no banner:
<img width="392" alt="Screen Shot 2022-08-09 at 5 45 52 PM" src="https://user-images.githubusercontent.com/17373817/183776786-80dc7c3d-6b6f-4aa3-a7bf-2e6f92833176.png">


Now, there is a banner:
<img width="392" alt="Screen Shot 2022-08-09 at 5 45 40 PM" src="https://user-images.githubusercontent.com/17373817/183776795-e7b1d83e-4bcf-46e1-b9d0-067733909d2e.png">



